### PR TITLE
Improve container health and request observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,6 +222,7 @@ COPY config.example.yaml /etc/triplet/config.yaml
 RUN ldd /usr/local/bin/triplet >/dev/null
 
 EXPOSE 8080
+HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD ["/usr/local/bin/triplet-healthcheck", "-url", "http://127.0.0.1:8080/healthz"]
 USER triplet:triplet
 ENTRYPOINT ["/usr/local/bin/triplet"]
 CMD ["-config", "/etc/triplet/config.yaml"]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,8 +5,8 @@
 server:
   # Address the HTTP server binds to.
   listen: ":8080"
-  read_timeout: 30s
-  write_timeout: 120s
+  read_timeout: 60s
+  write_timeout: 5m
   # Public base URL the server is reachable at. Used to build canonical
   # `id` fields in info.json and Link headers. Required.
   public_base_url: "${TRIPLET_PUBLIC_BASE_URL}"
@@ -155,7 +155,7 @@ sources:
   # http:
   #   allowed_hosts: [islandora-stage.lib.lehigh.edu]
   #   allow_private_hosts: false
-  #   request_timeout: 30s
+  #   request_timeout: 2m
   #   max_bytes: 52428800
   # gcs:
   #   bucket_url: gs://my-bucket

--- a/deploy/compose/config.yaml
+++ b/deploy/compose/config.yaml
@@ -51,7 +51,7 @@ sources:
   # http:
   #   allowed_hosts: [images.example.org]
   #   allow_private_hosts: false
-  #   request_timeout: 30s
+  #   request_timeout: 2m
   #   max_bytes: 52428800
 
 cache:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,11 @@ type Server struct {
 	PublicBaseURL string        `yaml:"public_base_url"`
 }
 
+const (
+	DefaultServerReadTimeout  = 60 * time.Second
+	DefaultServerWriteTimeout = 5 * time.Minute
+)
+
 // Logging controls slog setup.
 type Logging struct {
 	Level  string `yaml:"level"`
@@ -252,10 +257,10 @@ func (c *Config) applyDefaults() {
 		c.Server.Listen = ":8080"
 	}
 	if c.Server.ReadTimeout == 0 {
-		c.Server.ReadTimeout = 30 * time.Second
+		c.Server.ReadTimeout = DefaultServerReadTimeout
 	}
 	if c.Server.WriteTimeout == 0 {
-		c.Server.WriteTimeout = 120 * time.Second
+		c.Server.WriteTimeout = DefaultServerWriteTimeout
 	}
 	if c.Logging.Level == "" {
 		c.Logging.Level = "info"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -491,6 +491,12 @@ sources:
 	if c.Server.Listen != ":8080" {
 		t.Errorf("Listen default = %q", c.Server.Listen)
 	}
+	if c.Server.ReadTimeout != DefaultServerReadTimeout {
+		t.Errorf("ReadTimeout default = %s", c.Server.ReadTimeout)
+	}
+	if c.Server.WriteTimeout != DefaultServerWriteTimeout {
+		t.Errorf("WriteTimeout default = %s", c.Server.WriteTimeout)
+	}
 	if c.IIIF.Image.Prefix != "/iiif/3" {
 		t.Errorf("Image.Prefix default = %q", c.IIIF.Image.Prefix)
 	}

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -4,6 +4,7 @@ package observability
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -68,6 +69,8 @@ func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 				slog.String("request_id", rid),
 				slog.String("method", r.Method),
 				slog.String("path", redact.Path(r.URL.Path)),
+				slog.String("client_ip", clientIP(r)),
+				slog.String("user_agent", r.UserAgent()),
 				slog.Int("status", ww.status),
 				slog.Int64("bytes", ww.bytes),
 				slog.Duration("latency", time.Since(start)),
@@ -110,6 +113,22 @@ func (s *statusRecorder) Write(b []byte) (int, error) {
 	n, err := s.ResponseWriter.Write(b)
 	s.bytes += int64(n)
 	return n, err
+}
+
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ip, _, _ := strings.Cut(xff, ",")
+		if ip = strings.TrimSpace(ip); ip != "" {
+			return ip
+		}
+	}
+	if ip := strings.TrimSpace(r.Header.Get("X-Real-IP")); ip != "" {
+		return ip
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }
 
 func newRequestID() string {

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -65,6 +65,9 @@ func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 			ctx := context.WithValue(r.Context(), requestIDKey, rid)
 			ww := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(ww, r.WithContext(ctx))
+			if r.URL.Path == "/healthz" {
+				return
+			}
 			logger.LogAttrs(ctx, slog.LevelInfo, "http",
 				slog.String("request_id", rid),
 				slog.String("method", r.Method),

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -44,3 +44,19 @@ func TestClientIPFallsBackToRemoteAddrHost(t *testing.T) {
 		t.Fatalf("clientIP = %q, want %q", got, "192.0.2.10")
 	}
 }
+
+func TestLoggingMiddlewareSkipsHealthcheck(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+	LoggingMiddleware(logger)(next).ServeHTTP(rr, req)
+
+	if logs.Len() != 0 {
+		t.Fatalf("healthcheck log = %q, want empty", logs.String())
+	}
+}

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -1,0 +1,46 @@
+package observability
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggingMiddlewareIncludesClientIPAndUserAgent(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/iiif/3/example/info.json", nil)
+	req.RemoteAddr = "192.0.2.10:12345"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 192.0.2.10")
+	req.Header.Set("User-Agent", "triplet-test/1.0")
+
+	rr := httptest.NewRecorder()
+	LoggingMiddleware(logger)(next).ServeHTTP(rr, req)
+
+	var entry map[string]any
+	if err := json.Unmarshal(logs.Bytes(), &entry); err != nil {
+		t.Fatal(err)
+	}
+	if got := entry["client_ip"]; got != "203.0.113.9" {
+		t.Fatalf("client_ip = %#v, want %q", got, "203.0.113.9")
+	}
+	if got := entry["user_agent"]; got != "triplet-test/1.0" {
+		t.Fatalf("user_agent = %#v, want %q", got, "triplet-test/1.0")
+	}
+}
+
+func TestClientIPFallsBackToRemoteAddrHost(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.0.2.10:12345"
+
+	if got := clientIP(req); got != "192.0.2.10" {
+		t.Fatalf("clientIP = %q, want %q", got, "192.0.2.10")
+	}
+}

--- a/internal/storage/http.go
+++ b/internal/storage/http.go
@@ -37,10 +37,12 @@ type HTTPOpener struct {
 	ForwardAuthHeaders bool
 }
 
+const DefaultRequestTimeout = 2 * time.Minute
+
 // NewHTTPOpener constructs an HTTPOpener with sane timeouts.
 func NewHTTPOpener(allowedHosts []string, requestTimeout time.Duration, maxBytes int64) *HTTPOpener {
 	if requestTimeout == 0 {
-		requestTimeout = 30 * time.Second
+		requestTimeout = DefaultRequestTimeout
 	}
 	h := &HTTPOpener{
 		AllowedHosts: allowedHosts,

--- a/internal/storage/http_test.go
+++ b/internal/storage/http_test.go
@@ -100,6 +100,13 @@ func TestHTTPOpener(t *testing.T) {
 	})
 }
 
+func TestHTTPOpenerAppliesDefaultRequestTimeout(t *testing.T) {
+	op := NewHTTPOpener([]string{"example.org"}, 0, 0)
+	if op.Client.Timeout != DefaultRequestTimeout {
+		t.Fatalf("Client.Timeout = %s, want %s", op.Client.Timeout, DefaultRequestTimeout)
+	}
+}
+
 func TestHTTPOpenerRejectsRedirectToDeniedHost(t *testing.T) {
 	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "http://example.org/secret", http.StatusFound)


### PR DESCRIPTION
- add Docker HEALTHCHECK using triplet-healthcheck
- log client IP and user agent on HTTP access logs
- increase default server and HTTP source timeouts for slow IIIF sources
- document updated timeout defaults in sample configs